### PR TITLE
Fix agnostic watching of files

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,6 @@ Elixir.extend('replace', function(file, replacements, output) {
                    .pipe(replace(replacements))
                    .pipe(gulp.dest(dest));
     })
-    .watch('./resources/**');
+    .watch(file);
 
 });


### PR DESCRIPTION
`watch` is broken when using non-standard paths.

This PR fixes this by simply passing the file pattern to the `watch` task.
